### PR TITLE
Fix compilation errors in main.rs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,9 +2,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 use colored::Colorize;
 use flux_framework::{
-    cli::FluxCli,
     config::Config,
-    error::FluxError,
     helpers::logging::{init_logging, LogLevel},
     modules::ModuleManager,
     workflows::WorkflowManager,
@@ -150,7 +148,7 @@ async fn list_modules() -> Result<()> {
     if modules.is_empty() {
         println!("{}", "No modules found".red());
     } else {
-        for module in modules {
+        for module in &modules {
             let status = if module.is_executable() {
                 "✓".green()
             } else {
@@ -159,9 +157,9 @@ async fn list_modules() -> Result<()> {
 
             println!(
                 "{:<20} {} {}",
-                module.name().white(),
+                module.name.white(),
                 status,
-                module.description()
+                module.description
             );
         }
 


### PR DESCRIPTION
Fixed two compilation errors reported by GitHub CI:

1. ModuleDescriptor field access errors (lines 162, 164):
   - Changed module.name() to module.name
   - Changed module.description() to module.description
   - ModuleDescriptor has fields, not methods

2. Borrow of moved value error (line 153):
   - Changed 'for module in modules' to 'for module in &modules'
   - Prevents moving modules vector so it can be used later for .len()

Also cleaned up unused imports:
   - Removed unused cli::FluxCli import
   - Removed unused error::FluxError import

Build verified:
   - cargo check: ✅ No errors
   - cargo build --lib: ✅ Success
   - cargo build --bin flux: ✅ Success
   - Only warnings remain (unused imports in other files)